### PR TITLE
don't fade out pieces on navigation

### DIFF
--- a/src/components/Piece.svelte
+++ b/src/components/Piece.svelte
@@ -73,7 +73,10 @@
 <div class="container">
   {#each piece.scenes as scene, i}
     {#if sceneNumber === i}
-      <div in:fade={{ delay: 1500, duration: 1500 }} out:fade class="scene">
+      <div
+        in:fade|local={{ delay: 1500, duration: 1500 }}
+        out:fade|local
+        class="scene">
         <Scene {scene} />
       </div>
     {/if}


### PR DESCRIPTION
uses a [local transition](https://svelte.dev/tutorial/local-transitions) so that the scene-turn fades only occur _when the scene changes_ within the page component.

previously, that transition happened _whenever an element unmounted_. this means that if i were on `/`, then clicked on `arturo`, then clicked "back" on my browser navigation, since svelte renders this as an in-spa navigation, it would detect that the `scene` component unmounted and fade it out, rather than immediately remove it from the page